### PR TITLE
Bitcoin cash: deserialize position using the new format

### DIFF
--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -145,7 +145,12 @@ memory_ptr transaction_database::find(const hash_digest& hash,
     // Critical Section
     metadata_mutex_.lock_shared();
     const auto height = deserial.read_4_bytes_little_endian();
+#ifdef BITPRIM_CURRENCY_BCH
+    const auto position = deserial.read_4_bytes_little_endian();
+#else
     const auto position = deserial.read_2_bytes_little_endian();
+#endif
+
     ////const auto median_time_past = deserial.read_4_bytes_little_endian();
     metadata_mutex_.unlock_shared();
     ///////////////////////////////////////////////////////////////////////////
@@ -168,7 +173,12 @@ transaction_result transaction_database::get(const hash_digest& hash,
         metadata_mutex_.lock_shared();
         auto deserial = make_unsafe_deserializer(REMAP_ADDRESS(slab));
         const auto height = deserial.read_4_bytes_little_endian();
+#ifdef BITPRIM_CURRENCY_BCH
+        const auto position = deserial.read_4_bytes_little_endian();
+#else
         const auto position = deserial.read_2_bytes_little_endian();
+#endif
+
         const auto median_time_past = deserial.read_4_bytes_little_endian();
         metadata_mutex_.unlock_shared();
         ///////////////////////////////////////////////////////////////////////
@@ -198,7 +208,11 @@ bool transaction_database::get_output(output& out_output, size_t& out_height,
         metadata_mutex_.lock_shared();
         auto deserial = make_unsafe_deserializer(REMAP_ADDRESS(slab));
         out_height = deserial.read_4_bytes_little_endian();
+#ifdef BITPRIM_CURRENCY_BCH
+        out_coinbase = deserial.read_4_bytes_little_endian() == 0;
+#else
         out_coinbase = deserial.read_2_bytes_little_endian() == 0;
+#endif
         out_median_time_past = deserial.read_4_bytes_little_endian();
         metadata_mutex_.unlock_shared();
         ///////////////////////////////////////////////////////////////////////
@@ -230,7 +244,11 @@ bool transaction_database::get_output_is_confirmed(output& out_output, size_t& o
     metadata_mutex_.lock_shared();
     auto deserial = make_unsafe_deserializer(REMAP_ADDRESS(slab));
     out_height = deserial.read_4_bytes_little_endian();
+#ifdef BITPRIM_CURRENCY_BCH
+    out_coinbase = deserial.read_4_bytes_little_endian() == 0;
+#else
     out_coinbase = deserial.read_2_bytes_little_endian() == 0;
+#endif
     // out_median_time_past is not a parameter
     // out_median_time_past = deserial.read_4_bytes_little_endian();
     metadata_mutex_.unlock_shared();


### PR DESCRIPTION
The new position format was used when writting in the database but no when reading.